### PR TITLE
Fixed error when /root folder not exists

### DIFF
--- a/Custom_Firmware/Scripts/Dropbear/U2W.sh
+++ b/Custom_Firmware/Scripts/Dropbear/U2W.sh
@@ -25,6 +25,7 @@ ln -s /tmp/libz.so.1.2.11 /usr/lib/libz.so
 mkdir /root
 mkdir /root/.ssh
 cp /mnt/UPAN/cplay2air.pub /root/.ssh/authorized_keys
+chmod 700 /root
 chmod 700 /root/.ssh
 chmod 600 /root/.ssh/authorized_keys
 chown root:root /root


### PR DESCRIPTION
New versions of firmware missing /root folder (and its permissions). So when u trying to use dropbear problem appeared:
```
/root must be owned by user or root, and not writable by others
```